### PR TITLE
Update for libcamera v0.4.0+rpt20250213

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['meson-python', 'pyyaml', 'pybind11', 'jinja2', 'ply']
 
 [project]
 name = 'rpi-libcamera'
-version = '0.1a8'
+version = '0.1a11'
 description = 'libcamera python bindings'
 readme = 'README.md'
 
@@ -14,9 +14,9 @@ Source = "https://github.com/raspberrypi/pylibcamera"
 
 [tool.meson-python.args]
 setup = [
-    '-Drevision=v0.4.0+rpt20250127',
+    '-Drevision=v0.4.0+rpt20250213',
     '-Drepository=https://github.com/raspberrypi/libcamera.git',
-    '-Dversion=v0.4.0+50-83cb8101'
+    '-Dversion=v0.4.0+53-29156679'
 ]
 
 [tool.flit.module]


### PR DESCRIPTION
The following error occurred:

```
$ uv add rpi-libcamera
Resolved 70 packages in 138ms
   Built omni-mouse @ file:///home/tetsuya/omni-mouse                                                                     × Failed to build `rpi-libcamera==0.1a8`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `mesonpy.build_wheel` failed (exit status: 1)

      [stdout]
      + meson setup /home/tetsuya/.cache/uv/sdists-v6/pypi/rpi-libcamera/0.1a8/S4Hquzt6VB_yN8UQjvmdu/src
      /home/tetsuya/.cache/uv/sdists-v6/pypi/rpi-libcamera/0.1a8/S4Hquzt6VB_yN8UQjvmdu/src/.mesonpy-tbz4y5j1
      -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md -Drevision=v0.4.0+rpt20250127
      -Drepository=https://github.com/raspberrypi/libcamera.git -Dversion=v0.4.0+50-83cb8101
      --native-file=/home/tetsuya/.cache/uv/sdists-v6/pypi/rpi-libcamera/0.1a8/S4Hquzt6VB_yN8UQjvmdu/src/.mesonpy-tbz4y5j1/meson-python-native-file.ini
      The Meson build system
      Version: 1.7.0
      Source dir: /home/tetsuya/.cache/uv/sdists-v6/pypi/rpi-libcamera/0.1a8/S4Hquzt6VB_yN8UQjvmdu/src
      Build dir: /home/tetsuya/.cache/uv/sdists-v6/pypi/rpi-libcamera/0.1a8/S4Hquzt6VB_yN8UQjvmdu/src/.mesonpy-tbz4y5j1
      Build type: native build
      Project name: pylibcamera
      Project version: 0.1.0
      C compiler for the host machine: cc (gcc 12.2.0 "cc (Debian 12.2.0-14) 12.2.0")
      C linker for the host machine: cc ld.bfd 2.40
      C++ compiler for the host machine: c++ (gcc 12.2.0 "c++ (Debian 12.2.0-14) 12.2.0")
      C++ linker for the host machine: c++ ld.bfd 2.40
      Host machine cpu family: aarch64
      Host machine cpu: aarch64
      Message: Cloning from: https://github.com/raspberrypi/libcamera.git, revision v0.4.0+rpt20250127
      Message: libcamera version is v0.4.0+53-29156679


      ../meson.build:26:8: ERROR: Problem encountered: This package works with libcamera version v0.4.0+50-83cb8101,
      but you have version v0.4.0+53-29156679
       installed. Please check the readme for help with this error

      A full log can be found at
      /home/tetsuya/.cache/uv/sdists-v6/pypi/rpi-libcamera/0.1a8/S4Hquzt6VB_yN8UQjvmdu/src/.mesonpy-tbz4y5j1/meson-logs/meson-log.txt

      hint: This usually indicates a problem with the package or the build environment.
  help: `rpi-libcamera` (v0.1a8) was included because `omni-mouse` (v0.1.0) depends on `rpi-libcamera`
```

The toml file needed to be updated.